### PR TITLE
Add special discount endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@
     }
     ```
 
-- **Description:** Passing the phrase `EXTRA` grants a 50% discount on the product price. Using `EXTRA90` (and synonyms `EXTRA_90`, `EXTRA-90`, `MEGAEXTRA`, or `SUPEREXTRA`) triggers a 90% discount. Any other phrase leaves the price unchanged and returns an explanatory message.
+- **Description:** Passing the phrase `MINI` grants a 10% discount on the product price, while `EXTRA` grants 50%. Using `EXTRA90` (and synonyms `EXTRA_90`, `EXTRA-90`, `MEGAEXTRA`, or `SUPEREXTRA`) triggers a 90% discount. Any other phrase leaves the price unchanged and returns an explanatory message.
 
 #### 8. Simulate a Purchase
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,21 @@
     }
     ```
 
+#### 7.1. Get a Special Phrase Discount
+
+- **Method:** `POST`
+- **URL:** [http://localhost:8080/discount/special](http://localhost:8080/discount/special)
+- **Request Body:**
+
+    ```json
+    {
+        "productId": 1,
+        "promoCode": "EXTRA"
+    }
+    ```
+
+- **Description:** Passing the phrase `EXTRA` grants a 50% discount on the product price. Using `EXTRA90` (and synonyms `EXTRA_90`, `EXTRA-90`, `MEGAEXTRA`, or `SUPEREXTRA`) triggers a 90% discount. Any other phrase leaves the price unchanged and returns an explanatory message.
+
 #### 8. Simulate a Purchase
 
 - **Method:** `POST`

--- a/src/main/java/eu/sii/promocodes/controller/DiscountController.java
+++ b/src/main/java/eu/sii/promocodes/controller/DiscountController.java
@@ -1,7 +1,8 @@
 package eu.sii.promocodes.controller;
 
-import eu.sii.promocodes.model.dto.discount.DiscountResulRequestDto;
 import eu.sii.promocodes.model.dto.discount.DiscountResultResponseDto;
+import eu.sii.promocodes.model.dto.discount.DiscountResulRequestDto;
+import eu.sii.promocodes.model.dto.discount.SpecialDiscountRequestDto;
 import eu.sii.promocodes.service.DiscountService;
 import eu.sii.promocodes.utils.OperationUtils;
 import jakarta.validation.Valid;
@@ -21,6 +22,13 @@ public class DiscountController {
     public ResponseEntity<DiscountResultResponseDto> getTheDiscountPrice(@Valid @RequestBody DiscountResulRequestDto discountResulRequestDto, BindingResult bindingResult){
         OperationUtils.isRequestValid(bindingResult);
         return ResponseEntity.ok(discountService.getDiscountPrice(discountResulRequestDto));
+    }
+
+    @PostMapping("/special")
+    public ResponseEntity<DiscountResultResponseDto> getSpecialDiscount(@Valid @RequestBody SpecialDiscountRequestDto specialDiscountRequestDto,
+                                                                        BindingResult bindingResult) {
+        OperationUtils.isRequestValid(bindingResult);
+        return ResponseEntity.ok(discountService.getSpecialDiscountPrice(specialDiscountRequestDto));
     }
 
 }

--- a/src/main/java/eu/sii/promocodes/model/dto/discount/SpecialDiscountRequestDto.java
+++ b/src/main/java/eu/sii/promocodes/model/dto/discount/SpecialDiscountRequestDto.java
@@ -1,0 +1,24 @@
+package eu.sii.promocodes.model.dto.discount;
+
+import eu.sii.promocodes.model.dto.interfaces.ProductOperationRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SpecialDiscountRequestDto implements ProductOperationRequest {
+
+    @NotNull
+    private Long productId;
+
+    @NotBlank(message = "Secret phrase cannot be blank.")
+    @Pattern(regexp = "^\\S+$", message = "Secret phrase must not contain whitespace.")
+    private String promoCode;
+}

--- a/src/main/java/eu/sii/promocodes/service/DiscountService.java
+++ b/src/main/java/eu/sii/promocodes/service/DiscountService.java
@@ -2,13 +2,17 @@ package eu.sii.promocodes.service;
 
 import eu.sii.promocodes.exception.product.ProductNotFoundException;
 import eu.sii.promocodes.model.Product;
-import eu.sii.promocodes.model.dto.discount.DiscountResulRequestDto;
 import eu.sii.promocodes.model.dto.discount.DiscountResultResponseDto;
+import eu.sii.promocodes.model.dto.discount.SpecialDiscountRequestDto;
 import eu.sii.promocodes.model.dto.interfaces.ProductOperationRequest;
 import eu.sii.promocodes.repository.ProductRepository;
 import eu.sii.promocodes.utils.DiscountCalculatingUtils;
+import eu.sii.promocodes.utils.SpecialDiscountUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +28,29 @@ public class DiscountService {
                 .orElseThrow(() -> new ProductNotFoundException(productOperationRequest.getProductId()));
 
         return DiscountCalculatingUtils.calculateDiscountPrice(promoCode, product);
+    }
+
+    public DiscountResultResponseDto getSpecialDiscountPrice(SpecialDiscountRequestDto specialDiscountRequestDto) {
+        Product product = productRepository.findById(specialDiscountRequestDto.getProductId())
+                .orElseThrow(() -> new ProductNotFoundException(specialDiscountRequestDto.getProductId()));
+
+        BigDecimal discountPercentage = SpecialDiscountUtils.resolveDiscountPercentage(specialDiscountRequestDto.getPromoCode());
+        if (discountPercentage.compareTo(BigDecimal.ZERO) <= 0) {
+            return DiscountResultResponseDto.builder()
+                    .discountPrice(product.getRegularPrice())
+                    .discountMessage("Special discount phrase not recognized.")
+                    .productPriceCurrency(product.getCurrency())
+                    .build();
+        }
+
+        BigDecimal multiplier = BigDecimal.ONE.subtract(discountPercentage.divide(BigDecimal.valueOf(100), 4, RoundingMode.HALF_UP));
+        BigDecimal discountedPrice = product.getRegularPrice().multiply(multiplier).setScale(2, RoundingMode.HALF_UP);
+
+        return DiscountResultResponseDto.builder()
+                .discountPrice(discountedPrice.max(BigDecimal.ZERO))
+                .discountMessage(String.format("Special discount (%s%%) applied successfully.", discountPercentage.stripTrailingZeros().toPlainString()))
+                .productPriceCurrency(product.getCurrency())
+                .build();
     }
 
 }

--- a/src/main/java/eu/sii/promocodes/utils/SpecialDiscountUtils.java
+++ b/src/main/java/eu/sii/promocodes/utils/SpecialDiscountUtils.java
@@ -1,0 +1,25 @@
+package eu.sii.promocodes.utils;
+
+import lombok.experimental.UtilityClass;
+
+import java.math.BigDecimal;
+import java.util.Locale;
+
+@UtilityClass
+public class SpecialDiscountUtils {
+
+    private static final BigDecimal FIFTY_PERCENT = BigDecimal.valueOf(50);
+    private static final BigDecimal NINETY_PERCENT = BigDecimal.valueOf(90);
+
+    public static BigDecimal resolveDiscountPercentage(String phrase) {
+        if (phrase == null) {
+            return BigDecimal.ZERO;
+        }
+        String normalized = phrase.trim().toUpperCase(Locale.ROOT);
+        return switch (normalized) {
+            case "EXTRA" -> FIFTY_PERCENT;
+            case "EXTRA90", "EXTRA_90", "EXTRA-90", "MEGAEXTRA", "SUPEREXTRA" -> NINETY_PERCENT;
+            default -> BigDecimal.ZERO;
+        };
+    }
+}

--- a/src/main/java/eu/sii/promocodes/utils/SpecialDiscountUtils.java
+++ b/src/main/java/eu/sii/promocodes/utils/SpecialDiscountUtils.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 @UtilityClass
 public class SpecialDiscountUtils {
 
+    private static final BigDecimal TEN_PERCENT = BigDecimal.TEN;
     private static final BigDecimal FIFTY_PERCENT = BigDecimal.valueOf(50);
     private static final BigDecimal NINETY_PERCENT = BigDecimal.valueOf(90);
 
@@ -17,6 +18,7 @@ public class SpecialDiscountUtils {
         }
         String normalized = phrase.trim().toUpperCase(Locale.ROOT);
         return switch (normalized) {
+            case "MINI" -> TEN_PERCENT;
             case "EXTRA" -> FIFTY_PERCENT;
             case "EXTRA90", "EXTRA_90", "EXTRA-90", "MEGAEXTRA", "SUPEREXTRA" -> NINETY_PERCENT;
             default -> BigDecimal.ZERO;

--- a/src/test/java/eu/sii/promocodes/utils/SpecialDiscountUtilsTest.java
+++ b/src/test/java/eu/sii/promocodes/utils/SpecialDiscountUtilsTest.java
@@ -1,0 +1,17 @@
+package eu.sii.promocodes.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SpecialDiscountUtilsTest {
+
+    @Test
+    void shouldReturnTenPercentForMiniPhrase() {
+        BigDecimal discount = SpecialDiscountUtils.resolveDiscountPercentage("mini");
+
+        assertEquals(BigDecimal.TEN, discount);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated request DTO and controller entry-point for invoking special phrase discounts
- extend the discount service with logic to resolve 50% and 90% discounts based on special phrases
- document the new /discount/special endpoint and accepted phrases in the README

## Testing
- `mvn -q test` *(fails: network is unreachable while resolving the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d16beaede88323a357803e4a9ee33f